### PR TITLE
Update TransitionHelper.cs

### DIFF
--- a/src/BlazorDeferredRemove/TransitionHelper.cs
+++ b/src/BlazorDeferredRemove/TransitionHelper.cs
@@ -21,5 +21,11 @@ namespace BlazorDeferredRemove
         {
             await _transitionEndedCallback(name);
         }
+
+        [JSInvokable]
+        public async Task AnimationHasEnded(string name)
+        {
+            await _transitionEndedCallback(name);
+        }
     }
 }


### PR DESCRIPTION
Added JS Invoke method for AnimationHasEnded.  There was no Blazor invokable method from JS for Animations.

I just came across this when using the library and saw there was a recent comment in closed issue #1 that brought up this bug.